### PR TITLE
Change Python version for Certbot 3.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages
 from setuptools import setup
 
-version = '2.5.0'
+version = '2.6.0'
 
 # azure-mgmt-dns is still the old style SDK, so will change dramatically
 # when they refactor, most notably the credential parts
@@ -10,7 +10,7 @@ install_requires = [
     'azure-mgmt-dns>=8.0.0',
     'azure-core>=1.25.0',
     'setuptools>=41.6.0',
-    'certbot>=2.0,<3.0'
+    'certbot>=3.0'
 ]
 
 with open("README.md") as f:
@@ -31,7 +31,7 @@ setup(
     author="Terry Cain",
     author_email='opensource@bink.com',
     license='Apache License 2.0',
-    python_requires='>=3.6',
+    python_requires='>=3.11',
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Plugins',

--- a/snap-requirements.txt
+++ b/snap-requirements.txt
@@ -2,4 +2,4 @@ azure-identity>=1.13.0
 azure-mgmt-dns>=8.0.0
 azure-core>=1.25.0
 setuptools>=41.6.0
-certbot>=2.0,<3.0
+certbot>=3.0

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 
 name: certbot-dns-azure
 summary: Azure DNS Authenticator plugin for Certbot
-version: '2.5.0'
+version: '2.6.0'
 description: A certbot dns plugin to obtain certificates using Azure DNS. For information on how to set up, go to the GitHub page.
 website: https://github.com/terrycain/certbot-dns-azure
 license: Apache-2.0


### PR DESCRIPTION
Hello @terricain ,
Thanks for your plugin.

After updating certbot to 3.0 the plugin doesn't work because the python version is outdated. See: https://github.com/terricain/certbot-dns-azure/issues/52
I suggest this fix, which works in my test environment. I have upgraded to Python 3.11.
This is the first time I've contributed to a certbot plugin, so I hope I haven't missed anything :)
Thanks again for this wonderful plugin and the time you invest in its development !
